### PR TITLE
3. Fix setup circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,8 @@ jobs:
     docker:
       - image: circleci/ruby:2.7.0-node-browsers
       - image: circleci/postgres:12.2
+        environment:
+          POSTGRES_HOST_AUTH_METHOD: trust
     working_directory: ~/quizzy
     environment:
       TZ: '/usr/share/zoneinfo/America/New_York'


### PR DESCRIPTION
#3
Fixed: 
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD to a non-empty value for the
       superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".

       You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
       connections without a password. This is *not* recommended.

       See PostgreSQL documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html